### PR TITLE
MR-698 - GetAllPatchesAndAreas endpoint added, to populate Patch fields in Add Property MMH form

### DIFF
--- a/PatchesAndAreasApi.Tests/V1/Controllers/PatchesAndAreasApiControllerTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Controllers/PatchesAndAreasApiControllerTests.cs
@@ -327,19 +327,5 @@ namespace PatchesAndAreasApi.Tests.V1.Controllers
             var outcome = Assert.IsType<OkObjectResult>(result);
             var resultPatches = Assert.IsType<List<PatchesResponseObject>>(outcome.Value);
         }
-
-        [Fact]
-        public async Task GetAllPatchesExceptionIsThrown()
-        {
-            // Arrange
-            var exception = new ApplicationException("Test exception");
-            _mockGetAllPatchesUseCase.Setup(x => x.Execute()).ThrowsAsync(exception);
-
-            // Act
-            Func<Task<IActionResult>> func = async () => await _classUnderTest.GetAllPatches().ConfigureAwait(false);
-
-            // Assert
-            (await func.Should().ThrowAsync<ApplicationException>()).WithMessage(exception.Message);
-        }
     }
 }

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -277,28 +277,26 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
             _logger.VerifyExact(LogLevel.Debug, $"Querying PatchByParentId index for parentId {query.ParentId}", Times.Once());
         }
 
-        //[Fact]
-        //public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
-        //{
-        //    // Arrange
-        //    var patches = _fixture.Build<PatchesDb>()
-        //                          .With(x => x.VersionNumber, (int?) null)
-        //                          .Without(x => x.ResponsibleEntities)
-        //                          .CreateMany(5).ToList();
+        [Fact]
+        public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
+        {
+            // Arrange
+            var patches = _fixture.Build<PatchesDb>()
+                                  .CreateMany(5).ToList();
 
-        //    InsertListDataToDynamoDB(patches);
+            InsertListDataToDynamoDB(patches);
 
-        //    // Act
-        //    var results = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+            // Act
+            var results = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
 
-        //    // Assert
-        //    foreach (var patch in patches)
-        //    {
-        //        results.Should().ContainEquivalentOf(patch.ToDomain());
-        //    }
+            // Assert
+            foreach (var patch in patches)
+            {
+                results.Should().ContainEquivalentOf(patch.ToDomain());
+            }
 
-        //    _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
-        //}
+            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+        }
 
 
         private async Task InsertDataToDynamoDB(PatchesDb dbEntity)

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -277,18 +277,6 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
             _logger.VerifyExact(LogLevel.Debug, $"Querying PatchByParentId index for parentId {query.ParentId}", Times.Once());
         }
 
-        //[Fact]
-        //public async Task GetAllPatchesAsyncReturnsEmptyListIfNoPatchesExist()
-        //{
-        //    _dbFixture.DynamoDbContext.Dispose();
-        //    // Act
-        //    var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
-
-        //    // Assert
-        //    result.Should().BeEmpty();
-        //    _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
-        //}
-
         [Fact]
         public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
         {

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -293,8 +293,6 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
         public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
         {
             // Arrange
-            //_dbFixture.DynamoDbContext.Dispose();
-
             var patches = _fixture.Build<PatchesDb>()
                                   .With(x => x.VersionNumber, (int?) null)
                                   .Without(x => x.ResponsibleEntities)
@@ -303,10 +301,14 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
             InsertListDataToDynamoDB(patches);
 
             // Act
-            var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+            var results = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
 
             // Assert
-            result.Should().BeEquivalentTo(patches);
+            foreach (var patch in patches)
+            {
+                results.Should().ContainEquivalentOf(patch.ToDomain());
+            }
+
             _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
         }
 

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -281,11 +281,9 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
         public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
         {
             // Arrange
-            var patches = new List<PatchesDb>();
-
-            patches.AddRange(_fixture.Build<PatchesDb>()
+            var patches = _fixture.Build<PatchesDb>()
                                   .With(x => x.VersionNumber, (int?) null)
-                                  .CreateMany(5));
+                                  .CreateMany(5).ToList();
 
             InsertListDataToDynamoDB(patches);
 
@@ -298,7 +296,7 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
                 results.Should().ContainEquivalentOf(patch.ToDomain());
             }
 
-            //_logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
         }
 
 

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -282,6 +282,7 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
         {
             // Arrange
             var patches = _fixture.Build<PatchesDb>()
+                                  .With(x => x.VersionNumber, (int?) null)
                                   .CreateMany(5).ToList();
 
             InsertListDataToDynamoDB(patches);

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -277,36 +277,38 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
             _logger.VerifyExact(LogLevel.Debug, $"Querying PatchByParentId index for parentId {query.ParentId}", Times.Once());
         }
 
-        //[Fact]
-        //public async Task GetAllPatchesAsyncReturnsEmptyListIfNoPatchesExist()
-        //{
-        //    // Act
-        //    var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+        [Fact]
+        public async Task GetAllPatchesAsyncReturnsEmptyListIfNoPatchesExist()
+        {
+            _dbFixture.DynamoDbContext.Dispose();
+            // Act
+            var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
 
-        //    // Assert
-        //    result.Should().BeEmpty();
-        //    _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
-        //}
+            // Assert
+            result.Should().BeEmpty();
+            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+        }
 
-        //[Fact]
-        //public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
-        //{
-        //    // Arrange
-        //    var patches = new List<PatchesDb>();
+        [Fact]
+        public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
+        {
+            _dbFixture.DynamoDbContext.Dispose();
+            // Arrange
+            var patches = new List<PatchesDb>();
 
-        //    patches.AddRange(_fixture.Build<PatchesDb>()
-        //                          .With(x => x.VersionNumber, (int?) null)
-        //                          .CreateMany(5));
+            patches.AddRange(_fixture.Build<PatchesDb>()
+                                  .With(x => x.VersionNumber, (int?) null)
+                                  .CreateMany(5));
 
-        //    InsertListDataToDynamoDB(patches);
+            InsertListDataToDynamoDB(patches);
 
-        //    // Act
-        //    var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+            // Act
+            var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
 
-        //    // Assert
-        //    result.Should().BeEquivalentTo(patches);
-        //    _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
-        //}
+            // Assert
+            result.Should().BeEquivalentTo(patches);
+            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+        }
 
 
         private async Task InsertDataToDynamoDB(PatchesDb dbEntity)

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -277,28 +277,28 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
             _logger.VerifyExact(LogLevel.Debug, $"Querying PatchByParentId index for parentId {query.ParentId}", Times.Once());
         }
 
-        [Fact]
-        public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
-        {
-            // Arrange
-            var patches = _fixture.Build<PatchesDb>()
-                                  .With(x => x.VersionNumber, (int?) null)
-                                  .Without(x => x.ResponsibleEntities)
-                                  .CreateMany(5).ToList();
+        //[Fact]
+        //public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
+        //{
+        //    // Arrange
+        //    var patches = _fixture.Build<PatchesDb>()
+        //                          .With(x => x.VersionNumber, (int?) null)
+        //                          .Without(x => x.ResponsibleEntities)
+        //                          .CreateMany(5).ToList();
 
-            InsertListDataToDynamoDB(patches);
+        //    InsertListDataToDynamoDB(patches);
 
-            // Act
-            var results = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+        //    // Act
+        //    var results = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
 
-            // Assert
-            foreach (var patch in patches)
-            {
-                results.Should().ContainEquivalentOf(patch.ToDomain());
-            }
+        //    // Assert
+        //    foreach (var patch in patches)
+        //    {
+        //        results.Should().ContainEquivalentOf(patch.ToDomain());
+        //    }
 
-            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
-        }
+        //    _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+        //}
 
 
         private async Task InsertDataToDynamoDB(PatchesDb dbEntity)

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
+using Microsoft.Extensions.FileSystemGlobbing;
 
 namespace PatchesAndAreasApi.Tests.V1.Gateways
 {
@@ -94,7 +95,7 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
                                  .Create();
             var dbEntity = entity.ToDatabase();
 
-            await InsertDatatoDynamoDB(dbEntity).ConfigureAwait(false);
+            await InsertDataToDynamoDB(dbEntity).ConfigureAwait(false);
 
             var query = ConstructQuery(entity.Id);
             //Act
@@ -128,7 +129,7 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
                 .Create();
             var dbPatch = mockPatch.ToDatabase();
 
-            await InsertDatatoDynamoDB(dbPatch).ConfigureAwait(false);
+            await InsertDataToDynamoDB(dbPatch).ConfigureAwait(false);
 
             var mockRequest = new DeleteResponsibilityFromPatchRequest
             {
@@ -157,7 +158,7 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
 
             var responsibilityToRemove = mockResponsibileEntity.First();
             var dbEntity = mockPatch.ToDatabase();
-            await InsertDatatoDynamoDB(dbEntity).ConfigureAwait(false);
+            await InsertDataToDynamoDB(dbEntity).ConfigureAwait(false);
 
             var mockRequest = new DeleteResponsibilityFromPatchRequest
             {
@@ -186,7 +187,7 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
                                  .With(x => x.VersionNumber, (int?) null)
                                  .Create();
             var dbEntity = entity.ToDatabase();
-            await InsertDatatoDynamoDB(dbEntity).ConfigureAwait(false);
+            await InsertDataToDynamoDB(dbEntity).ConfigureAwait(false);
 
 
             var query = ConstructUpdateQuery(entity.Id, Guid.NewGuid());
@@ -230,7 +231,7 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
             var query = ConstructUpdateQuery(entity.Id, entity.ResponsibleEntities.First().Id);
             var dbEntity = entity.ToDatabase();
 
-            await InsertDatatoDynamoDB(dbEntity).ConfigureAwait(false);
+            await InsertDataToDynamoDB(dbEntity).ConfigureAwait(false);
             entity.VersionNumber = 0;
 
             var constructRequest = ConstructUpdateRequest(query.ResponsibileEntityId);
@@ -266,7 +267,7 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
                                   .With(x => x.VersionNumber, (int?) null)
 
                                   .CreateMany(5));
-            InsertListDatatoDynamoDB(patches);
+            InsertListDataToDynamoDB(patches);
 
             var query = new GetPatchByParentIdQuery() { ParentId = parentid };
             var response = await _classUnderTest.GetByParentIdAsync(query).ConfigureAwait(false);
@@ -276,12 +277,44 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
             _logger.VerifyExact(LogLevel.Debug, $"Querying PatchByParentId index for parentId {query.ParentId}", Times.Once());
         }
 
-        private async Task InsertDatatoDynamoDB(PatchesDb dbEntity)
+        [Fact]
+        public async Task GetAllPatchesAsyncReturnsEmptyListIfNoPatchesExist()
+        {
+            // Act
+            var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+
+            // Assert
+            result.Should().BeEmpty();
+            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+        }
+
+        [Fact]
+        public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
+        {
+            // Arrange
+            var patches = new List<PatchesDb>();
+
+            patches.AddRange(_fixture.Build<PatchesDb>()
+                                  .With(x => x.VersionNumber, (int?) null)
+                                  .CreateMany(5));
+
+            InsertListDataToDynamoDB(patches);
+
+            // Act
+            var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+
+            // Assert
+            result.Should().BeEquivalentTo(patches);
+            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+        }
+
+
+        private async Task InsertDataToDynamoDB(PatchesDb dbEntity)
         {
             await _dbFixture.SaveEntityAsync(dbEntity).ConfigureAwait(false);
         }
 
-        private void InsertListDatatoDynamoDB(List<PatchesDb> dbEntity)
+        private void InsertListDataToDynamoDB(List<PatchesDb> dbEntity)
         {
             foreach (var patch in dbEntity)
             {

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -277,28 +277,28 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
             _logger.VerifyExact(LogLevel.Debug, $"Querying PatchByParentId index for parentId {query.ParentId}", Times.Once());
         }
 
-        [Fact]
-        public async Task GetAllPatchesAsyncReturnsEmptyListIfNoPatchesExist()
-        {
-            _dbFixture.DynamoDbContext.Dispose();
-            // Act
-            var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+        //[Fact]
+        //public async Task GetAllPatchesAsyncReturnsEmptyListIfNoPatchesExist()
+        //{
+        //    _dbFixture.DynamoDbContext.Dispose();
+        //    // Act
+        //    var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
 
-            // Assert
-            result.Should().BeEmpty();
-            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
-        }
+        //    // Assert
+        //    result.Should().BeEmpty();
+        //    _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+        //}
 
         [Fact]
         public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
         {
-            _dbFixture.DynamoDbContext.Dispose();
             // Arrange
-            var patches = new List<PatchesDb>();
+            //_dbFixture.DynamoDbContext.Dispose();
 
-            patches.AddRange(_fixture.Build<PatchesDb>()
+            var patches = _fixture.Build<PatchesDb>()
                                   .With(x => x.VersionNumber, (int?) null)
-                                  .CreateMany(5));
+                                  .Without(x => x.ResponsibleEntities)
+                                  .CreateMany(5).ToList();
 
             InsertListDataToDynamoDB(patches);
 

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -277,36 +277,36 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
             _logger.VerifyExact(LogLevel.Debug, $"Querying PatchByParentId index for parentId {query.ParentId}", Times.Once());
         }
 
-        [Fact]
-        public async Task GetAllPatchesAsyncReturnsEmptyListIfNoPatchesExist()
-        {
-            // Act
-            var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+        //[Fact]
+        //public async Task GetAllPatchesAsyncReturnsEmptyListIfNoPatchesExist()
+        //{
+        //    // Act
+        //    var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
 
-            // Assert
-            result.Should().BeEmpty();
-            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
-        }
+        //    // Assert
+        //    result.Should().BeEmpty();
+        //    _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+        //}
 
-        [Fact]
-        public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
-        {
-            // Arrange
-            var patches = new List<PatchesDb>();
+        //[Fact]
+        //public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
+        //{
+        //    // Arrange
+        //    var patches = new List<PatchesDb>();
 
-            patches.AddRange(_fixture.Build<PatchesDb>()
-                                  .With(x => x.VersionNumber, (int?) null)
-                                  .CreateMany(5));
+        //    patches.AddRange(_fixture.Build<PatchesDb>()
+        //                          .With(x => x.VersionNumber, (int?) null)
+        //                          .CreateMany(5));
 
-            InsertListDataToDynamoDB(patches);
+        //    InsertListDataToDynamoDB(patches);
 
-            // Act
-            var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+        //    // Act
+        //    var result = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
 
-            // Assert
-            result.Should().BeEquivalentTo(patches);
-            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
-        }
+        //    // Assert
+        //    result.Should().BeEquivalentTo(patches);
+        //    _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+        //}
 
 
         private async Task InsertDataToDynamoDB(PatchesDb dbEntity)

--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -281,14 +281,16 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
         public async Task GetAllPatchesAsyncReturnsAllPatchesIfTheyExist()
         {
             // Arrange
-            var patches = _fixture.Build<PatchesDb>()
+            var patches = new List<PatchesDb>();
+
+            patches.AddRange(_fixture.Build<PatchesDb>()
                                   .With(x => x.VersionNumber, (int?) null)
-                                  .CreateMany(5).ToList();
+                                  .CreateMany(5));
 
             InsertListDataToDynamoDB(patches);
 
             // Act
-            var results = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
+            var results = await _classUnderTest.GetAllPatchesAsync();
 
             // Assert
             foreach (var patch in patches)
@@ -296,7 +298,7 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
                 results.Should().ContainEquivalentOf(patch.ToDomain());
             }
 
-            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
+            //_logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
         }
 
 

--- a/PatchesAndAreasApi.Tests/V1/UseCase/GetAllPatchesUseCaseTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/UseCase/GetAllPatchesUseCaseTests.cs
@@ -1,0 +1,56 @@
+using PatchesAndAreasApi.V1.Gateways;
+using PatchesAndAreasApi.V1.UseCase;
+using Moq;
+using Xunit;
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using AutoFixture;
+using Hackney.Shared.PatchesAndAreas.Domain;
+using System.Collections.Generic;
+
+namespace PatchesAndAreasApi.Tests.V1.UseCase
+{
+    [Collection("LogCall collection")]
+    public class GetAllPatchesUseCaseTests
+    {
+        private Mock<IPatchesGateway> _mockGateway;
+        private GetAllPatchesUseCase _classUnderTest;
+        private readonly Fixture _fixture = new Fixture();
+
+
+        public GetAllPatchesUseCaseTests()
+        {
+            _mockGateway = new Mock<IPatchesGateway>();
+            _classUnderTest = new GetAllPatchesUseCase(_mockGateway.Object);
+        }
+
+        [Fact]
+        public async Task GetAllPatchesUseCaseReturnsReturnsAllPatches()
+        {
+            // Arrange
+            var patchesResponse = _fixture.Create<List<PatchEntity>>();
+            _mockGateway.Setup(x => x.GetAllPatchesAsync()).ReturnsAsync(patchesResponse);
+
+            // Act
+            var response = await _classUnderTest.Execute().ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(patchesResponse, response);
+        }
+
+        [Fact]
+        public async Task GetAllPatchesUseCaseThrowsException()
+        {
+            // Arrange
+            var exception = new ApplicationException("Test exception");
+            _mockGateway.Setup(x => x.GetAllPatchesAsync()).ThrowsAsync(exception);
+
+            // Act
+            Func<Task<List<PatchEntity>>> func = async () => await _classUnderTest.Execute().ConfigureAwait(false);
+
+            // Assert
+            (await func.Should().ThrowAsync<ApplicationException>()).WithMessage(exception.Message);
+        }
+    }
+}

--- a/PatchesAndAreasApi/Startup.cs
+++ b/PatchesAndAreasApi/Startup.cs
@@ -174,7 +174,7 @@ namespace PatchesAndAreasApi
             services.AddScoped<IDeleteResponsibilityFromPatchUseCase, DeleteResponsibilityFromPatchUseCase>();
             services.AddScoped<IUpdatePatchResponsibilitiesUseCase, UpdatePatchResponsibilitiesUseCase>();
             services.AddScoped<IGetPatchByParentIdUseCase, GetPatchByParentIdUseCase>();
-
+            services.AddScoped<IGetAllPatchesUseCase, GetAllPatchesUseCase>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/PatchesAndAreasApi/V1/Controllers/PatchesAndAreasApiController.cs
+++ b/PatchesAndAreasApi/V1/Controllers/PatchesAndAreasApiController.cs
@@ -38,7 +38,7 @@ namespace PatchesAndAreasApi.V1.Controllers
             _getPatchByParentIdUseCase = getPatchByParentIdUseCase;
             _updatePatchResponsibilities = updatePatchResponsibilities;
             _deleteResponsibilityFromPatchUseCase = deleteResponsibilityFromPatchUseCase;
-            _getAllPatchesUseCase= getAllPatchesUseCase;
+            _getAllPatchesUseCase = getAllPatchesUseCase;
             _contextWrapper = contextWrapper;
         }
 

--- a/PatchesAndAreasApi/V1/Controllers/PatchesAndAreasApiController.cs
+++ b/PatchesAndAreasApi/V1/Controllers/PatchesAndAreasApiController.cs
@@ -27,17 +27,38 @@ namespace PatchesAndAreasApi.V1.Controllers
         private readonly IDeleteResponsibilityFromPatchUseCase _deleteResponsibilityFromPatchUseCase;
         private readonly IUpdatePatchResponsibilitiesUseCase _updatePatchResponsibilities;
         private readonly IGetPatchByParentIdUseCase _getPatchByParentIdUseCase;
+        private readonly IGetAllPatchesUseCase _getAllPatchesUseCase;
         private readonly IHttpContextWrapper _contextWrapper;
 
         public PatchesAndAreasApiController(IGetPatchByIdUseCase getByIdUseCase, IUpdatePatchResponsibilitiesUseCase updatePatchResponsibilities,
             IGetPatchByParentIdUseCase getPatchByParentIdUseCase, IDeleteResponsibilityFromPatchUseCase deleteResponsibilityFromPatchUseCase,
-            IHttpContextWrapper contextWrapper)
+            IGetAllPatchesUseCase getAllPatchesUseCase, IHttpContextWrapper contextWrapper)
         {
             _getByIdUseCase = getByIdUseCase;
             _getPatchByParentIdUseCase = getPatchByParentIdUseCase;
             _updatePatchResponsibilities = updatePatchResponsibilities;
             _deleteResponsibilityFromPatchUseCase = deleteResponsibilityFromPatchUseCase;
+            _getAllPatchesUseCase= getAllPatchesUseCase;
             _contextWrapper = contextWrapper;
+        }
+
+        /// <summary>
+        /// Retrives all Patch records
+        /// </summary>
+        /// <response code="200">Success</response>
+        /// <response code="500">Something went wrong</response>
+        [ProducesResponseType(typeof(PatchesResponseObject), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        [HttpGet]
+        [LogCall(LogLevel.Information)]
+        [Route("")]
+        public async Task<IActionResult> GetAllPatches()
+        {
+            var allPatches = await _getAllPatchesUseCase.Execute().ConfigureAwait(false);
+
+            return Ok(allPatches.ToResponse());
         }
 
         /// <summary>

--- a/PatchesAndAreasApi/V1/Controllers/PatchesAndAreasApiController.cs
+++ b/PatchesAndAreasApi/V1/Controllers/PatchesAndAreasApiController.cs
@@ -53,7 +53,7 @@ namespace PatchesAndAreasApi.V1.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [HttpGet]
         [LogCall(LogLevel.Information)]
-        [Route("")]
+        [Route("all")]
         public async Task<IActionResult> GetAllPatches()
         {
             var allPatches = await _getAllPatchesUseCase.Execute().ConfigureAwait(false);

--- a/PatchesAndAreasApi/V1/Gateways/IPatchesGateway.cs
+++ b/PatchesAndAreasApi/V1/Gateways/IPatchesGateway.cs
@@ -8,12 +8,10 @@ namespace PatchesAndAreasApi.V1.Gateways
 {
     public interface IPatchesGateway
     {
+        Task<List<PatchEntity>> GetAllPatchesAsync();
         Task<PatchEntity> GetPatchByIdAsync(PatchesQueryObject query);
-        Task<PatchesDb> UpdatePatchResponsibilities(UpdatePatchesResponsibilityRequest query, UpdatePatchesResponsibilitiesRequestObject requestObject,
-                                                                                         int? ifMatch);
+        Task<PatchesDb> UpdatePatchResponsibilities(UpdatePatchesResponsibilityRequest query, UpdatePatchesResponsibilitiesRequestObject requestObject, int? ifMatch);
         Task<List<PatchEntity>> GetByParentIdAsync(GetPatchByParentIdQuery query);
-
-
         Task<PatchesDb> DeleteResponsibilityFromPatch(DeleteResponsibilityFromPatchRequest query);
 
     }

--- a/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
+++ b/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
@@ -12,6 +12,7 @@ using Hackney.Shared.PatchesAndAreas.Boundary.Request;
 using Hackney.Shared.PatchesAndAreas.Infrastructure;
 using Hackney.Shared.PatchesAndAreas.Infrastructure.Exceptions;
 using Hackney.Shared.PatchesAndAreas.Factories;
+using System.Collections;
 
 namespace PatchesAndAreasApi.V1.Gateways
 {
@@ -32,6 +33,8 @@ namespace PatchesAndAreasApi.V1.Gateways
         [LogCall]
         public async Task<List<PatchEntity>> GetAllPatchesAsync()
         {
+            _logger.LogDebug($"Calling IDynamoDBContext.ScanAsync for all PatchEntity records");
+
             var scanConfig = new ScanOperationConfig();
 
             var tableScan = await _dynamoDbContext.GetTargetTable<PatchesDb>().Scan(scanConfig).GetRemainingAsync().ConfigureAwait(false);

--- a/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
+++ b/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
@@ -30,6 +30,17 @@ namespace PatchesAndAreasApi.V1.Gateways
         }
 
         [LogCall]
+        public async Task<List<PatchEntity>> GetAllPatchesAsync()
+        {
+            var scanConfig = new ScanOperationConfig();
+
+            var tableScan = await _dynamoDbContext.GetTargetTable<PatchesDb>().Scan(scanConfig).GetRemainingAsync().ConfigureAwait(false);
+            var result = _dynamoDbContext.FromDocuments<PatchesDb>(tableScan);
+
+            return result.Select(x => x.ToDomain()).ToList();
+        }
+
+        [LogCall]
         public async Task<PatchEntity> GetPatchByIdAsync(PatchesQueryObject query)
         {
             _logger.LogDebug($"Calling IDynamoDBContext.LoadAsync for id parameter {query.Id}");

--- a/PatchesAndAreasApi/V1/UseCase/GetAllPatchesUseCase.cs
+++ b/PatchesAndAreasApi/V1/UseCase/GetAllPatchesUseCase.cs
@@ -18,8 +18,7 @@ namespace PatchesAndAreasApi.V1.UseCase
         [LogCall]
         public async Task<List<PatchEntity>> Execute()
         {
-            var allPatches = await _gateway.GetAllPatchesAsync().ConfigureAwait(false);
-            return allPatches;
+            return await _gateway.GetAllPatchesAsync().ConfigureAwait(false);
         }
     }
 }

--- a/PatchesAndAreasApi/V1/UseCase/GetAllPatchesUseCase.cs
+++ b/PatchesAndAreasApi/V1/UseCase/GetAllPatchesUseCase.cs
@@ -1,12 +1,8 @@
 using Hackney.Core.Logging;
-using Hackney.Shared.PatchesAndAreas.Boundary.Request;
 using Hackney.Shared.PatchesAndAreas.Domain;
 using PatchesAndAreasApi.V1.Gateways;
 using PatchesAndAreasApi.V1.UseCase.Interfaces;
-using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace PatchesAndAreasApi.V1.UseCase

--- a/PatchesAndAreasApi/V1/UseCase/GetAllPatchesUseCase.cs
+++ b/PatchesAndAreasApi/V1/UseCase/GetAllPatchesUseCase.cs
@@ -1,0 +1,29 @@
+using Hackney.Core.Logging;
+using Hackney.Shared.PatchesAndAreas.Boundary.Request;
+using Hackney.Shared.PatchesAndAreas.Domain;
+using PatchesAndAreasApi.V1.Gateways;
+using PatchesAndAreasApi.V1.UseCase.Interfaces;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PatchesAndAreasApi.V1.UseCase
+{
+    public class GetAllPatchesUseCase : IGetAllPatchesUseCase
+    {
+        private IPatchesGateway _gateway;
+        public GetAllPatchesUseCase(IPatchesGateway gateway)
+        {
+            _gateway = gateway;
+        }
+
+        [LogCall]
+        public async Task<List<PatchEntity>> Execute()
+        {
+            var allPatches = await _gateway.GetAllPatchesAsync().ConfigureAwait(false);
+            return allPatches;
+        }
+    }
+}

--- a/PatchesAndAreasApi/V1/UseCase/Interfaces/IGetAllPatchesUseCase.cs
+++ b/PatchesAndAreasApi/V1/UseCase/Interfaces/IGetAllPatchesUseCase.cs
@@ -1,0 +1,12 @@
+using Hackney.Shared.PatchesAndAreas.Boundary.Request;
+using Hackney.Shared.PatchesAndAreas.Domain;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace PatchesAndAreasApi.V1.UseCase.Interfaces
+{
+    public interface IGetAllPatchesUseCase
+    {
+        Task<List<PatchEntity>> Execute();
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

[MR-698](https://hackney.atlassian.net/jira/software/c/projects/MR/boards/88?modal=detail&selectedIssue=MR-698)

## Describe this PR

### *What is the problem we're trying to solve*

Add new Asset form (MMH) will need to allow a user to pick one or more Patches to assign to the property/asset that's being created.

This endpoint should allow us to fetch all records from the database and populate a dropdown, with all available patches.

We initially explored the option to potentially move index the data in ElasticSearch, but as the production PatchesAndAreas DynamoDB instance only has 54 records, a full Scan of the database is a very fast and effortless operation.

### *What changes have we introduced*

#### _Checklist_

- [x] Added GET endpoint /patch/all in Controller
- [x] Added UseCase and related Interface
- [x] Added Gateway method
- [x] Added tests for controller, usecase and gateway methods
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Modify Add Asset form in MMH, so that on page load, it calls this GET endpoint and populates Patch field dropdown

[MR-698]: https://hackney.atlassian.net/browse/MR-698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ