### PR TITLE
Add authorisation to ReplacePatchResponsibleEntities

### DIFF
--- a/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
+++ b/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="Hackney.Core.Authorization" Version="1.79.0-feat-regenerate-0002" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.55.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />

--- a/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
+++ b/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
-    <PackageReference Include="Hackney.Core.Authorization" Version="1.79.0-feat-regenerate-0002" />
+    <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.55.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />

--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Stories/ReplacePatchResponsibleEntitiesTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Stories/ReplacePatchResponsibleEntitiesTests.cs
@@ -29,7 +29,6 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Stories
             _patchFixture = new PatchesFixtures(_dbFixture.DynamoDbContext, _snsFixture.SimpleNotificationService);
             _steps = new ReplacePatchResponsibleEntitiesStep(appFactory.Client);
 
-            // AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
             if (Environment.GetEnvironmentVariable("ASSET_ADMIN_GROUPS") == null)
                 Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "e2e-testing");
         }

--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Stories/ReplacePatchResponsibleEntitiesTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Stories/ReplacePatchResponsibleEntitiesTests.cs
@@ -28,7 +28,14 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Stories
             _snsFixture = appFactory.SnsFixture;
             _patchFixture = new PatchesFixtures(_dbFixture.DynamoDbContext, _snsFixture.SimpleNotificationService);
             _steps = new ReplacePatchResponsibleEntitiesStep(appFactory.Client);
+
+            // AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
+            if (Environment.GetEnvironmentVariable("ASSET_ADMIN_GROUPS") == null)
+                Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "e2e-testing");
         }
+
+
+
 
         public void Dispose()
         {

--- a/PatchesAndAreasApi/PatchesAndAreasApi.csproj
+++ b/PatchesAndAreasApi/PatchesAndAreasApi.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="AWSXRayRecorder.Core" Version="2.11.1" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.8.1" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.9.1" />
+    <PackageReference Include="Hackney.Core.Authorization" Version="1.79.0-feat-regenerate-0002" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />

--- a/PatchesAndAreasApi/PatchesAndAreasApi.csproj
+++ b/PatchesAndAreasApi/PatchesAndAreasApi.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="AWSXRayRecorder.Core" Version="2.11.1" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.8.1" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.9.1" />
-    <PackageReference Include="Hackney.Core.Authorization" Version="1.79.0-feat-regenerate-0002" />
+    <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />

--- a/PatchesAndAreasApi/V1/Controllers/PatchesAndAreasApiController.cs
+++ b/PatchesAndAreasApi/V1/Controllers/PatchesAndAreasApiController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Net.Http.Headers;
 using Hackney.Core.Http;
 using System.Collections.Generic;
+using Hackney.Core.Authorization;
 using Hackney.Shared.PatchesAndAreas.Boundary.Response;
 using Hackney.Shared.PatchesAndAreas.Boundary.Request;
 using Hackney.Shared.PatchesAndAreas.Infrastructure.Exceptions;
@@ -153,6 +154,7 @@ namespace PatchesAndAreasApi.V1.Controllers
         [HttpPut]
         [Route("{id}/responsibleEntities")]
         [LogCall(LogLevel.Information)]
+        [AuthorizeEndpointByGroups("ASSET_ADMIN_GROUPS")]
         public async Task<IActionResult> ReplacePatchResponsibleEntities([FromRoute] PatchesQueryObject query,
                                                                           [FromBody] List<ResponsibleEntities> responsibleEntitiesRequestObject)
         {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - AWS_REGION=eu-west-2
       - AWS_ACCESS_KEY_ID=local
       - AWS_SECRET_ACCESS_KEY=local
+      - ASSET_ADMIN_GROUPS=mmh-project-team
     links:
       - dynamodb-database
       - localstack
@@ -36,6 +37,7 @@ services:
       - AWS_REGION=eu-west-2
       - AWS_ACCESS_KEY_ID=local
       - AWS_SECRET_ACCESS_KEY=local
+      - ASSET_ADMIN_GROUPS=e2e-testing
     links:
       - dynamodb-database
       - localstack
@@ -59,5 +61,3 @@ services:
     volumes:
       - "./.localstack:/tmp/localstack"
       - "/var/run/docker.sock:/var/run/docker.sock"
-      
-  


### PR DESCRIPTION
## [MR-764](https://hackney.atlassian.net/jira/software/c/projects/MR/boards/88?selectedIssue=MR-764)

PUT `patch/{id}/responsibleEntities`
Endpoint needs authorisation to ensure the client user is in the asset admin google group(s) (as on parameter store)

[MR-764]: https://hackney.atlassian.net/browse/MR-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ