### PR TITLE
fix old data and new data that is being sent to sns

### DIFF
--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Fixtures/PatchesFixtures.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Fixtures/PatchesFixtures.cs
@@ -33,7 +33,9 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Fixtures
         public UpdatePatchesResponsibilitiesRequestObject UpdateResponsibleRequestObject
         { get; private set; }
 
-        public List<ResponsibleEntities> ResponsibleEntities { get; private set; }
+        public List<ResponsibleEntities> NewResponsibleEntities { get; private set; }
+
+        public List<ResponsibleEntities> OldResponsibleEntities { get; private set; }
         public ResponsibleEntities ResponsibleEntity { get; private set; }
         public string InvalidParentId { get; private set; }
 
@@ -143,6 +145,7 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Fixtures
                                  .With(x => x.ResponsibleEntities, responsibleEntityList)
                                  .Without(x => x.VersionNumber)
                                  .Create();
+            OldResponsibleEntities = responsibleEntityList;
             return (entity, responsibleEntityList);
         }
 
@@ -157,10 +160,16 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Fixtures
                 _dbContext.SaveAsync<PatchesDb>(patch).GetAwaiter().GetResult();
                 PatchesDb = patch;
                 Id = patch.Id;
-                var newResponsibleEntity = _fixture.Create<ResponsibleEntities>();
-                responsibleEntityList.Add(newResponsibleEntity);
 
-                ResponsibleEntities = responsibleEntityList;
+                var newResponsibleEntity = _fixture.Create<ResponsibleEntities>();
+                var newResponsibleEntityList = new List<ResponsibleEntities>
+                {
+                    responsibleEntityList.FirstOrDefault(),
+                    responsibleEntityList.LastOrDefault(),
+                    newResponsibleEntity
+                };
+
+                NewResponsibleEntities = newResponsibleEntityList;
                 ResponsibleEntity = newResponsibleEntity;
             }
         }
@@ -174,13 +183,18 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Fixtures
                 var responsibleEntityList = entity.Item2;
 
                 var toBeDeletedResponsibleEntity = _fixture.Create<ResponsibleEntities>();
-                responsibleEntityList.Add(toBeDeletedResponsibleEntity);
+                var newResponsibleEntityList = new List<ResponsibleEntities>
+                {
+                    responsibleEntityList.FirstOrDefault(),
+                    responsibleEntityList.LastOrDefault(),
+                    toBeDeletedResponsibleEntity
+                };
                 _dbContext.SaveAsync<PatchesDb>(patch).GetAwaiter().GetResult();
                 PatchesDb = patch;
                 Id = patch.Id;
-                responsibleEntityList.Remove(toBeDeletedResponsibleEntity);
+                newResponsibleEntityList.Remove(toBeDeletedResponsibleEntity);
 
-                ResponsibleEntities = responsibleEntityList;
+                NewResponsibleEntities = newResponsibleEntityList;
                 ResponsibleEntity = toBeDeletedResponsibleEntity;
             }
         }

--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
@@ -83,6 +83,17 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
 
             Action<PatchesAndAreasSns> verifyFunc = (actual) =>
             {
+                var expectedOldData = new Dictionary<string, List<ResponsibleEntities>>()
+                {
+                    {"Entities", patchesFixture.OldResponsibleEntities }
+                };
+                var expectedNewData = new Dictionary<string, List<ResponsibleEntities>>()
+                {
+                    {"Entities", patchesFixture.NewResponsibleEntities }
+                };
+                actual.EventData.OldValues.Should().BeEquivalentTo(expectedOldData);
+                actual.EventData.NewValues.Should().BeEquivalentTo(expectedNewData);
+
                 actual.CorrelationId.Should().NotBeEmpty();
                 actual.EntityId.Should().Be(patchesFixture.Id);
                 actual.EventType.Should().Be(PatchOrAreaResEntityEditedEventConstants.EVENTTYPE);
@@ -99,6 +110,7 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
             if (!snsResult && snsVerifer.LastException != null)
                 throw snsVerifer.LastException;
         }
+
 
         public async Task ThenConflictIsReturned(int? versionNumber)
         {

--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
@@ -124,5 +124,10 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
         {
             _lastResponse.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
+        public async Task ThenUnauthorizedIsReturned()
+        {
+            _lastResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+        }
     }
 }

--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Stories/ReplacePatchResponsibleEntitiesTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Stories/ReplacePatchResponsibleEntitiesTests.cs
@@ -102,6 +102,17 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Stories
                 .BDDfy();
         }
 
+        [Fact]
+        public void ServiceReturnsUnauthorizedWhenUserIsNotInAllowedGroups()
+        {
+            Environment.SetEnvironmentVariable("ASSET_ADMIN_GROUPS", "unauthorized-group");
+
+            this.Given(g => _patchFixture.GivenAnReplacePatchResponsibleEntitiesWithNewResponsibleEntityRequest())
+                .And(g => _steps.WhenTheReplaceResponsibilityEntityApiIsCalled(_patchFixture.Id, _patchFixture.NewResponsibleEntities))
+                .Then(t => _steps.ThenUnauthorizedIsReturned())
+                .BDDfy();
+        }
+
 
     }
 }

--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Stories/ReplacePatchResponsibleEntitiesTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Stories/ReplacePatchResponsibleEntitiesTests.cs
@@ -64,7 +64,7 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Stories
         {
 
             this.Given(g => _patchFixture.GivenAnReplacePatchResponsibleEntitiesWithNewResponsibleEntityRequest())
-                .When(w => _steps.WhenTheReplaceResponsibilityEntityApiIsCalled(_patchFixture.Id, _patchFixture.ResponsibleEntities, versionNumber))
+                .When(w => _steps.WhenTheReplaceResponsibilityEntityApiIsCalled(_patchFixture.Id, _patchFixture.NewResponsibleEntities, versionNumber))
                 .Then(t => _steps.ThenConflictIsReturned(versionNumber))
                 .BDDfy();
         }
@@ -73,8 +73,8 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Stories
         public void ServiceUpdateTheRequestedPatchWithNewResponsibleEntity()
         {
             this.Given(g => _patchFixture.GivenAnReplacePatchResponsibleEntitiesWithNewResponsibleEntityRequest())
-                .And(g => _steps.WhenTheReplaceResponsibilityEntityApiIsCalled(_patchFixture.Id, _patchFixture.ResponsibleEntities))
-                .Then(t => _steps.ThenTheResponsibilityEntityIsReplacedWithEntitySentFromClient(_patchFixture, _patchFixture.ResponsibleEntities, _patchFixture.ResponsibleEntity))
+                .And(g => _steps.WhenTheReplaceResponsibilityEntityApiIsCalled(_patchFixture.Id, _patchFixture.NewResponsibleEntities))
+                .Then(t => _steps.ThenTheResponsibilityEntityIsReplacedWithEntitySentFromClient(_patchFixture, _patchFixture.NewResponsibleEntities, _patchFixture.ResponsibleEntity))
                 .Then(t => _steps.ThenThePatchOrAreaResEntityEditedEventIsRaised(_patchFixture, _snsFixture))
                 .BDDfy();
         }
@@ -84,8 +84,8 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Stories
         public void ServiceUpdateTheRequestedPatchWhenResponsibleEntityIsRemoved()
         {
             this.Given(g => _patchFixture.GivenAReplacePatchResponsibleEntitiesWithRemovingResponsibleEntityRequest())
-                .And(g => _steps.WhenTheReplaceResponsibilityEntityApiIsCalled(_patchFixture.Id, _patchFixture.ResponsibleEntities))
-                .Then(t => _steps.ThenTheResponsibilityEntityIsReplacedWithEntitySentFromClient(_patchFixture, _patchFixture.ResponsibleEntities, _patchFixture.ResponsibleEntity))
+                .And(g => _steps.WhenTheReplaceResponsibilityEntityApiIsCalled(_patchFixture.Id, _patchFixture.NewResponsibleEntities))
+                .Then(t => _steps.ThenTheResponsibilityEntityIsReplacedWithEntitySentFromClient(_patchFixture, _patchFixture.NewResponsibleEntities, _patchFixture.ResponsibleEntity))
                 .Then(t => _steps.ThenThePatchOrAreaResEntityEditedEventIsRaised(_patchFixture, _snsFixture))
                 .BDDfy();
         }

--- a/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
+++ b/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
@@ -1,5 +1,7 @@
 using Hackney.Core.Sns;
+using Hackney.Shared.PatchesAndAreas.Domain;
 using System;
+using System.Collections.Generic;
 
 namespace PatchesAndAreasApi.V1.Domain
 {
@@ -28,7 +30,7 @@ namespace PatchesAndAreasApi.V1.Domain
 
     public class EventData
     {
-        public object OldValues { get; set; }
-        public object NewValues { get; set; }
+        public Dictionary<string, List<ResponsibleEntities>> OldValues { get; set; }
+        public Dictionary<string, List<ResponsibleEntities>> NewValues { get; set; }
     }
 }

--- a/PatchesAndAreasApi/V1/Factories/PatchSnsFactory.cs
+++ b/PatchesAndAreasApi/V1/Factories/PatchSnsFactory.cs
@@ -14,6 +14,14 @@ namespace PatchesAndAreasApi.V1.Factories
     {
         public PatchesAndAreasSns Update(PatchesDb updateResult, Token token, List<ResponsibleEntities> previousResponsibleEntities)
         {
+            var oldValues = new Dictionary<string, List<ResponsibleEntities>>
+            {
+                { "Entities", previousResponsibleEntities }
+            };
+            var newValues = new Dictionary<string, List<ResponsibleEntities>>
+            {
+                { "Entities", updateResult.ResponsibleEntities }
+            };
             return new PatchesAndAreasSns
             {
                 CorrelationId = Guid.NewGuid(),
@@ -31,8 +39,8 @@ namespace PatchesAndAreasApi.V1.Factories
                 },
                 EventData = new EventData
                 {
-                    OldValues = previousResponsibleEntities,
-                    NewValues = updateResult.ResponsibleEntities
+                    OldValues = oldValues,
+                    NewValues = newValues
                 }
             };
         }


### PR DESCRIPTION
When sending a SNS message it didn't send through the new data and old data as that was not set as a list within the dictionary hence it caused conversion issues. This PR fixes this issue and relevant tests have been added to ensure that it works as expected.

Also, I've added a test to ensure that unauthorized groups are not able to access the endpoint. 