### PR TITLE
Fix-sns-message

### DIFF
--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System;
 using Hackney.Shared.PatchesAndAreas.Infrastructure.Constants;
 using System.Collections.Generic;
+using System.Linq;
 using Hackney.Core.Testing.Sns;
 using PatchesAndAreasApi.V1.Domain;
 using PatchesAndAreasApi.V1.Infrastructure;
@@ -80,16 +81,8 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
 
             Action<PatchesAndAreasSns> verifyFunc = (actual) =>
             {
-                var expectedOldData = new Dictionary<string, List<ResponsibleEntities>>()
-                {
-                    {"Entities", patchesFixture.OldResponsibleEntities }
-                };
-                var expectedNewData = new Dictionary<string, List<ResponsibleEntities>>()
-                {
-                    {"Entities", patchesFixture.NewResponsibleEntities }
-                };
-                actual.EventData.OldValues.Should().BeEquivalentTo(expectedOldData);
-                actual.EventData.NewValues.Should().BeEquivalentTo(expectedNewData);
+                actual.EventData.OldValues.Should().BeEquivalentTo(patchesFixture.OldResponsibleEntities.FirstOrDefault());
+                actual.EventData.NewValues.Should().BeEquivalentTo(patchesFixture.NewResponsibleEntities.FirstOrDefault());
 
                 actual.CorrelationId.Should().NotBeEmpty();
                 actual.EntityId.Should().Be(patchesFixture.Id);

--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
@@ -15,6 +15,7 @@ using Hackney.Core.Testing.Sns;
 using Bogus;
 using PatchesAndAreasApi.V1.Domain;
 using PatchesAndAreasApi.V1.Infrastructure;
+using System.Linq;
 
 namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
 {
@@ -83,15 +84,16 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
 
             Action<PatchesAndAreasSns> verifyFunc = (actual) =>
             {
-                var expectedOldData = new Dictionary<string, List<ResponsibleEntities>>()
+                var convertListToObj = patchesFixture.OldResponsibleEntities.Select(x => x as object).ToArray();
+                var expectedOldData = new Dictionary<string, object>()
                 {
-                    {"Entities", patchesFixture.OldResponsibleEntities }
+                    {"Entities", convertListToObj }
                 };
-                var expectedNewData = new Dictionary<string, List<ResponsibleEntities>>()
+                var expectedNewData = new Dictionary<string, object>()
                 {
                     {"Entities", patchesFixture.NewResponsibleEntities }
                 };
-                actual.EventData.OldValues.Should().BeEquivalentTo(expectedOldData);
+                actual.EventData.OldValues.Should().ContainEquivalentOf(expectedOldData);
                 actual.EventData.NewValues.Should().BeEquivalentTo(expectedNewData);
 
                 actual.CorrelationId.Should().NotBeEmpty();

--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/ReplacePatchResponsibleEntitiesStep.cs
@@ -12,10 +12,8 @@ using System;
 using Hackney.Shared.PatchesAndAreas.Infrastructure.Constants;
 using System.Collections.Generic;
 using Hackney.Core.Testing.Sns;
-using Bogus;
 using PatchesAndAreasApi.V1.Domain;
 using PatchesAndAreasApi.V1.Infrastructure;
-using System.Linq;
 
 namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
 {
@@ -25,7 +23,7 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
         { }
 
         /// <summary>
-        /// You can use jwt.io to decode the token - it is the same one we'd use on dev, etc. 
+        /// You can use jwt.io to decode the token - it is the same one we'd use on dev, etc.
         /// </summary>
         /// <param name="requestObject"></param>
         /// <returns></returns>
@@ -58,7 +56,6 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
         public async Task WhenTheReplaceResponsibilityEntityApiIsCalled(Guid id, List<ResponsibleEntities> responsibleEntities, int? ifMatch)
         {
             _lastResponse = await CallAPI(id, responsibleEntities, ifMatch).ConfigureAwait(false);
-
         }
 
         public async Task ThenTheResponsibilityEntityIsReplacedWithEntitySentFromClient(PatchesFixtures patchFixture, List<ResponsibleEntities> responsibleEntities, ResponsibleEntities responsibleEntity)
@@ -80,20 +77,18 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
 
         public async Task ThenThePatchOrAreaResEntityEditedEventIsRaised(PatchesFixtures patchesFixture, ISnsFixture snsFixture)
         {
-            var dbPatch = await patchesFixture._dbContext.LoadAsync<PatchesDb>(patchesFixture.Id).ConfigureAwait(false);
 
             Action<PatchesAndAreasSns> verifyFunc = (actual) =>
             {
-                var convertListToObj = patchesFixture.OldResponsibleEntities.Select(x => x as object).ToArray();
-                var expectedOldData = new Dictionary<string, object>()
+                var expectedOldData = new Dictionary<string, List<ResponsibleEntities>>()
                 {
-                    {"Entities", convertListToObj }
+                    {"Entities", patchesFixture.OldResponsibleEntities }
                 };
-                var expectedNewData = new Dictionary<string, object>()
+                var expectedNewData = new Dictionary<string, List<ResponsibleEntities>>()
                 {
                     {"Entities", patchesFixture.NewResponsibleEntities }
                 };
-                actual.EventData.OldValues.Should().ContainEquivalentOf(expectedOldData);
+                actual.EventData.OldValues.Should().BeEquivalentTo(expectedOldData);
                 actual.EventData.NewValues.Should().BeEquivalentTo(expectedNewData);
 
                 actual.CorrelationId.Should().NotBeEmpty();

--- a/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/UpdatePatchResponsibilityStep.cs
+++ b/PatchesAndAreasApi.Tests/V1/E2ETests/Steps/UpdatePatchResponsibilityStep.cs
@@ -1,13 +1,11 @@
 using FluentAssertions;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Hackney.Shared.PatchesAndAreas.Boundary.Request;
 using Hackney.Shared.PatchesAndAreas.Domain;
 using Hackney.Shared.PatchesAndAreas.Infrastructure;
 using Hackney.Shared.PatchesAndAreas.Infrastructure.Constants;
 using PatchesAndAreasApi.Tests.V1.E2ETests.Fixtures;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -23,11 +21,14 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
         { }
 
         /// <summary>
-        /// You can use jwt.io to decode the token - it is the same one we'd use on dev, etc. 
+        /// You can use jwt.io to decode the token - it is the same one we'd use on dev, etc.
         /// </summary>
+        /// <param name="id"></param>
+        /// <param name="responsibileEntityId"></param>
         /// <param name="requestObject"></param>
+        /// <param name="ifMatch"></param>
         /// <returns></returns>
-        public async Task<HttpResponseMessage> CallAPI(Guid id, Guid responsibileEntityId, UpdatePatchesResponsibilitiesRequestObject requestObject, int? ifMatch)
+        private async Task<HttpResponseMessage> CallAPI(Guid id, Guid responsibileEntityId, UpdatePatchesResponsibilitiesRequestObject requestObject, int? ifMatch)
         {
             var token =
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMTUwMTgxMTYwOTIwOTg2NzYxMTMiLCJlbWFpbCI6ImUyZS10ZXN0aW5nQGRldmVsb3BtZW50LmNvbSIsImlzcyI6IkhhY2tuZXkiLCJuYW1lIjoiVGVzdGVyIiwiZ3JvdXBzIjpbImUyZS10ZXN0aW5nIl0sImlhdCI6MTYyMzA1ODIzMn0.SooWAr-NUZLwW8brgiGpi2jZdWjyZBwp4GJikn0PvEw";
@@ -80,7 +81,9 @@ namespace PatchesAndAreasApi.Tests.V1.E2ETests.Steps
                                    .Should()
                                    .BeEquivalentTo(patchFixture.PatchesDb.ResponsibleEntities);
 
-            _cleanup.Add(async () => await patchFixture._dbContext.DeleteAsync<PatchesDb>(result.Id).ConfigureAwait(false));
+            async void Item() => await patchFixture._dbContext.DeleteAsync<PatchesDb>(result.Id).ConfigureAwait(false);
+
+            _cleanup.Add(Item);
         }
 
         public async Task ThenConflictIsReturned(int? versionNumber)

--- a/PatchesAndAreasApi.Tests/V1/UseCase/ReplacePatchResponsibleEntitiesUseCaseTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/UseCase/ReplacePatchResponsibleEntitiesUseCaseTests.cs
@@ -69,13 +69,13 @@ namespace PatchesAndAreasApi.Tests.V1.UseCase
 
             _mockGateway.Setup(x => x.ReplacePatchResponsibleEntities(query, request, ifMatch)).ReturnsAsync(gatewayResponse);
             var snsEvent = _fixture.Create<PatchesAndAreasSns>();
-            _mockSnsFactory.Setup(x => x.Update(gatewayResponse, token, It.IsAny<List<ResponsibleEntities>>()))
+            _mockSnsFactory.Setup(x => x.Update(gatewayResponse, token, It.IsAny<ResponsibleEntities>()))
                            .Returns(snsEvent);
             //Act
             var response = await _classUnderTest.ExecuteAsync(query, request, ifMatch, token).ConfigureAwait(false);
             //Assert
             response.Should().BeEquivalentTo(gatewayResponse.ToDomain().ToResponse());
-            _mockSnsFactory.Verify(x => x.Update(gatewayResponse, token, It.IsAny<List<ResponsibleEntities>>()), Times.Once);
+            _mockSnsFactory.Verify(x => x.Update(gatewayResponse, token, It.IsAny<ResponsibleEntities>()), Times.Once);
             _mockSnsGateway.Verify(x => x.Publish(snsEvent, It.IsAny<string>(), It.IsAny<string>()), Times.Once);
         }
 
@@ -95,7 +95,7 @@ namespace PatchesAndAreasApi.Tests.V1.UseCase
 
             //Assert
             response.Should().BeNull();
-            _mockSnsFactory.Verify(x => x.Update(It.IsAny<PatchesDb>(), token, It.IsAny<List<ResponsibleEntities>>()), Times.Never);
+            _mockSnsFactory.Verify(x => x.Update(It.IsAny<PatchesDb>(), token, It.IsAny<ResponsibleEntities>()), Times.Never);
             _mockSnsGateway.Verify(x => x.Publish(It.IsAny<PatchesAndAreasSns>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
         }

--- a/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
+++ b/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
@@ -30,7 +30,7 @@ namespace PatchesAndAreasApi.V1.Domain
 
     public class EventData
     {
-        public Dictionary<string, object> OldValues { get; set; }
-        public Dictionary<string, object> NewValues { get; set; }
+        public Dictionary<string, List<ResponsibleEntities>> OldValues { get; set; }
+        public Dictionary<string, List<ResponsibleEntities>> NewValues { get; set; }
     }
 }

--- a/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
+++ b/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
@@ -30,7 +30,7 @@ namespace PatchesAndAreasApi.V1.Domain
 
     public class EventData
     {
-        public Dictionary<string, List<ResponsibleEntities>> OldValues { get; set; }
-        public Dictionary<string, List<ResponsibleEntities>> NewValues { get; set; }
+        public Dictionary<string, object> OldValues { get; set; }
+        public Dictionary<string, object> NewValues { get; set; }
     }
 }

--- a/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
+++ b/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
@@ -30,7 +30,7 @@ namespace PatchesAndAreasApi.V1.Domain
 
     public class EventData
     {
-        public Dictionary<string, List<ResponsibleEntities>> OldValues { get; set; }
-        public Dictionary<string, List<ResponsibleEntities>> NewValues { get; set; }
+        public ResponsibleEntities OldValues { get; set; }
+        public ResponsibleEntities NewValues { get; set; }
     }
 }

--- a/PatchesAndAreasApi/V1/Factories/ISnsFactory.cs
+++ b/PatchesAndAreasApi/V1/Factories/ISnsFactory.cs
@@ -9,6 +9,6 @@ namespace PatchesAndAreasApi.V1.Factories
 {
     public interface ISnsFactory
     {
-        PatchesAndAreasSns Update(PatchesDb updateResult, Token token, List<ResponsibleEntities> previousResponsibleEntities);
+        PatchesAndAreasSns Update(PatchesDb updateResult, Token token, ResponsibleEntities previousResponsibleEntity);
     }
 }

--- a/PatchesAndAreasApi/V1/Factories/PatchSnsFactory.cs
+++ b/PatchesAndAreasApi/V1/Factories/PatchSnsFactory.cs
@@ -14,12 +14,10 @@ namespace PatchesAndAreasApi.V1.Factories
     {
         public PatchesAndAreasSns Update(PatchesDb updateResult, Token token, List<ResponsibleEntities> previousResponsibleEntities)
         {
-            var oldValues = new Dictionary<string, object> { };
-            foreach (var entity in previousResponsibleEntities)
-            {
-
-            }
-            var newValues = new Dictionary<string, object>
+            var oldValues = new Dictionary<string, List<ResponsibleEntities>> {
+                { "Entities", previousResponsibleEntities }
+            };
+            var newValues = new Dictionary<string, List<ResponsibleEntities>>
             {
                 { "Entities", updateResult.ResponsibleEntities }
             };

--- a/PatchesAndAreasApi/V1/Factories/PatchSnsFactory.cs
+++ b/PatchesAndAreasApi/V1/Factories/PatchSnsFactory.cs
@@ -14,11 +14,12 @@ namespace PatchesAndAreasApi.V1.Factories
     {
         public PatchesAndAreasSns Update(PatchesDb updateResult, Token token, List<ResponsibleEntities> previousResponsibleEntities)
         {
-            var oldValues = new Dictionary<string, List<ResponsibleEntities>>
+            var oldValues = new Dictionary<string, object> { };
+            foreach (var entity in previousResponsibleEntities)
             {
-                { "Entities", previousResponsibleEntities }
-            };
-            var newValues = new Dictionary<string, List<ResponsibleEntities>>
+
+            }
+            var newValues = new Dictionary<string, object>
             {
                 { "Entities", updateResult.ResponsibleEntities }
             };

--- a/PatchesAndAreasApi/V1/Factories/PatchSnsFactory.cs
+++ b/PatchesAndAreasApi/V1/Factories/PatchSnsFactory.cs
@@ -6,21 +6,15 @@ using PatchesAndAreasApi.V1.Domain;
 using PatchesAndAreasApi.V1.Infrastructure;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using EventData = PatchesAndAreasApi.V1.Domain.EventData;
 
 namespace PatchesAndAreasApi.V1.Factories
 {
     public class PatchSnsFactory : ISnsFactory
     {
-        public PatchesAndAreasSns Update(PatchesDb updateResult, Token token, List<ResponsibleEntities> previousResponsibleEntities)
+        public PatchesAndAreasSns Update(PatchesDb updateResult, Token token, ResponsibleEntities previousResponsibleEntity)
         {
-            var oldValues = new Dictionary<string, List<ResponsibleEntities>> {
-                { "Entities", previousResponsibleEntities }
-            };
-            var newValues = new Dictionary<string, List<ResponsibleEntities>>
-            {
-                { "Entities", updateResult.ResponsibleEntities }
-            };
             return new PatchesAndAreasSns
             {
                 CorrelationId = Guid.NewGuid(),
@@ -38,8 +32,8 @@ namespace PatchesAndAreasApi.V1.Factories
                 },
                 EventData = new EventData
                 {
-                    OldValues = oldValues,
-                    NewValues = newValues
+                    OldValues = previousResponsibleEntity,
+                    NewValues = updateResult.ResponsibleEntities.FirstOrDefault()
                 }
             };
         }

--- a/PatchesAndAreasApi/V1/Gateways/IPatchesGateway.cs
+++ b/PatchesAndAreasApi/V1/Gateways/IPatchesGateway.cs
@@ -12,7 +12,7 @@ namespace PatchesAndAreasApi.V1.Gateways
         Task<PatchEntity> GetPatchByIdAsync(PatchesQueryObject query);
         Task<PatchesDb> UpdatePatchResponsibilities(UpdatePatchesResponsibilityRequest query, UpdatePatchesResponsibilitiesRequestObject requestObject, int? ifMatch);
         Task<PatchesDb> ReplacePatchResponsibleEntities(PatchesQueryObject query, List<ResponsibleEntities> responsibleEntitiesRequestObject, int? ifMatch);
-        List<ResponsibleEntities> OldResponsibleEntities { get; }
+        ResponsibleEntities OldResponsibleEntity { get; }
 
         Task<List<PatchEntity>> GetByParentIdAsync(GetPatchByParentIdQuery query);
         Task<PatchesDb> DeleteResponsibilityFromPatch(DeleteResponsibilityFromPatchRequest query);

--- a/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
+++ b/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
@@ -24,7 +24,7 @@ namespace PatchesAndAreasApi.V1.Gateways
         private readonly ILogger<PatchesGateway> _logger;
         private const string GETPATCHBYPARENTIDINDEX = "PatchByParentId";
 
-        public List<ResponsibleEntities> OldResponsibleEntities { get; private set; }
+        public ResponsibleEntities OldResponsibleEntity { get; private set; }
 
         public PatchesGateway(IDynamoDBContext dynamoDbContext, ILogger<PatchesGateway> logger)
         {
@@ -104,7 +104,7 @@ namespace PatchesAndAreasApi.V1.Gateways
             _logger.LogDebug($"Calling IDynamoDBContext.LoadAsync for id {query.Id} and then IDynamoDBContext.SaveAsync");
             var patch = await _dynamoDbContext.LoadAsync<PatchesDb>(query.Id).ConfigureAwait(false);
             if (patch == null) return null;
-            OldResponsibleEntities = patch.ResponsibleEntities;
+            OldResponsibleEntity = patch.ResponsibleEntities.FirstOrDefault();
 
             if (ifMatch != patch.VersionNumber)
                 throw new VersionNumberConflictException(ifMatch, patch.VersionNumber);

--- a/PatchesAndAreasApi/V1/UseCase/ReplacePatchResponsibleEntitiesUseCase.cs
+++ b/PatchesAndAreasApi/V1/UseCase/ReplacePatchResponsibleEntitiesUseCase.cs
@@ -34,7 +34,7 @@ namespace PatchesAndAreasApi.V1.UseCase
             var updateResult = await _gateway.ReplacePatchResponsibleEntities(query, responsibleEntitiesRequestObject, ifMatch).ConfigureAwait(false);
             if (updateResult == null) return null;
 
-            var patchSnsMessage = _snsFactory.Update(updateResult, token, _gateway.OldResponsibleEntities);
+            var patchSnsMessage = _snsFactory.Update(updateResult, token, _gateway.OldResponsibleEntity);
             var tokenArn = Environment.GetEnvironmentVariable("PATCHES_AND_AREAS_SNS_ARN");
             await _snsGateway.Publish(patchSnsMessage, tokenArn).ConfigureAwait(false);
 


### PR DESCRIPTION
Send a single responsible entity object in SNS instead of a list to be compatible with our listener