### PR TITLE
Fix old data and new data sns message

### DIFF
--- a/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
+++ b/PatchesAndAreasApi/V1/Domain/PatchesAndAreasSns.cs
@@ -30,7 +30,7 @@ namespace PatchesAndAreasApi.V1.Domain
 
     public class EventData
     {
-        public ResponsibleEntities OldValues { get; set; }
-        public ResponsibleEntities NewValues { get; set; }
+        public object OldValues { get; set; }
+        public object NewValues { get; set; }
     }
 }

--- a/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
+++ b/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
@@ -104,6 +104,9 @@ namespace PatchesAndAreasApi.V1.Gateways
             _logger.LogDebug($"Calling IDynamoDBContext.LoadAsync for id {query.Id} and then IDynamoDBContext.SaveAsync");
             var patch = await _dynamoDbContext.LoadAsync<PatchesDb>(query.Id).ConfigureAwait(false);
             if (patch == null) return null;
+
+            // For our currently usecase we always expect for there to be only one person responsibile to a patch/area
+            // hence only sending the first object to SNS
             OldResponsibleEntity = patch.ResponsibleEntities.FirstOrDefault();
 
             if (ifMatch != patch.VersionNumber)


### PR DESCRIPTION
Old data and new data are not being set when sending the SNS message to AH Queue. This PR should fix that issue. 