### PR TITLE
Update Hackney.Shared.PatchesAndAreas ver

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,8 @@ orbs:
   aws-ecr: circleci/aws-ecr@3.0.0
   aws-cli: circleci/aws-cli@0.1.9
   aws_assume_role: lbh-hackit/aws_assume_role@0.1.0
-  sonarcloud: sonarsource/sonarcloud@1.1.1
+  sonarcloud: sonarsource/sonarcloud@2.0.0
+
 executors:
   docker-python:
     docker:
@@ -117,7 +118,7 @@ commands:
             apt-get update && apt-get install -y nodejs
       - run:
           name: Install serverless CLI
-          command: npm i -g serverless
+          command: npm i -g serverless@^3
       - run:
           name: Build lambda
           command: |

--- a/PatchesAndAreasApi.Tests/Dockerfile
+++ b/PatchesAndAreasApi.Tests/Dockerfile
@@ -26,9 +26,7 @@ COPY ./PatchesAndAreasApi/PatchesAndAreasApi.csproj ./PatchesAndAreasApi/
 COPY ./PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj ./PatchesAndAreasApi.Tests/
 COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./PatchesAndAreasApi/PatchesAndAreasApi.csproj \
-&& dotnet restore ./PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
-
+RUN dotnet restore
 # Copy everything else and build
 COPY . .
 

--- a/PatchesAndAreasApi.Tests/Dockerfile
+++ b/PatchesAndAreasApi.Tests/Dockerfile
@@ -13,8 +13,8 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 WORKDIR /app
 
 # Install and run sonar cloud scanner
-RUN apt-get update && apt-get install -y openjdk-11-jdk
-RUN dotnet tool install --global dotnet-sonarscanner --version 5.6.0
+RUN apt-get update && apt-get install -y openjdk-17-jdk && apt-get clean
+RUN dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 
 RUN dotnet sonarscanner begin /k:"LBHackney-IT_patches-and-areas-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"

--- a/PatchesAndAreasApi.Tests/Dockerfile
+++ b/PatchesAndAreasApi.Tests/Dockerfile
@@ -13,11 +13,12 @@ ENV SONAR_TOKEN=$SONAR_TOKEN
 WORKDIR /app
 
 # Install and run sonar cloud scanner
-RUN apt-get update && apt-get install -y openjdk-17-jdk && apt-get clean
-RUN dotnet tool install --global dotnet-sonarscanner
+RUN apt-get update && apt-get install -y openjdk-17-jdk && apt-get clean \
+&& dotnet tool install --global dotnet-sonarscanner
 ENV PATH="$PATH:/root/.dotnet/tools"
 
-RUN dotnet sonarscanner begin /k:"LBHackney-IT_patches-and-areas-api" /o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
+RUN dotnet sonarscanner begin /k:"LBHackney-IT_patches-and-areas-api" \
+/o:"lbhackney-it" /d:sonar.host.url=https://sonarcloud.io /d:sonar.login="${SONAR_TOKEN}"
 
 # Copy csproj and nuget config and restore as distinct layers
 COPY ./PatchesAndAreasApi.sln ./
@@ -25,15 +26,15 @@ COPY ./PatchesAndAreasApi/PatchesAndAreasApi.csproj ./PatchesAndAreasApi/
 COPY ./PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj ./PatchesAndAreasApi.Tests/
 COPY /NuGet.Config /root/.nuget/NuGet/NuGet.Config
 
-RUN dotnet restore ./PatchesAndAreasApi/PatchesAndAreasApi.csproj
-RUN dotnet restore ./PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
+RUN dotnet restore ./PatchesAndAreasApi/PatchesAndAreasApi.csproj \
+&& dotnet restore ./PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
 
 # Copy everything else and build
 COPY . .
 
-RUN dotnet build -c Release -o out PatchesAndAreasApi/PatchesAndAreasApi.csproj
-RUN dotnet build -c debug -o out PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
+RUN dotnet build -c Release -o out PatchesAndAreasApi/PatchesAndAreasApi.csproj \
+&& dotnet build -c debug -o out PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
 
-CMD dotnet test
+CMD ["dotnet", "test"]
 RUN dotnet sonarscanner end /d:sonar.login="${SONAR_TOKEN}"
 

--- a/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
+++ b/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.55.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
     <PackageReference Include="Hackney.Core.Testing.Sns" Version="1.71.0" />
-    <PackageReference Include="Hackney.Shared.PatchesAndAreas" Version="0.9.0" />
       <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/PatchesAndAreasApi/PatchesAndAreasApi.csproj
+++ b/PatchesAndAreasApi/PatchesAndAreasApi.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.PatchesAndAreas" Version="0.9.0" />
+    <PackageReference Include="Hackney.Shared.PatchesAndAreas" Version="0.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />
@@ -48,7 +48,7 @@
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="6.7.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/HPT-392

## Describe this PR

- Add new enums from `Hackney.Shared.PatchesAndAreas`.
- Update Sonar Scanner version (see https://github.com/LBHackney-IT/asset-information-api/pull/144)
- Fixed some complaints about the dockerfile from sonarcloud (b728d8a)

## Shared package upgrade
Shared package bumped from v9 to v13.

Changes behind the in-between releases:
1. https://github.com/LBHackney-IT/patches-and-areas-shared/pull/5 - v10
2. https://github.com/LBHackney-IT/patches-and-areas-shared/pull/6 (reverts the previous) - v11
3. https://github.com/LBHackney-IT/patches-and-areas-shared/pull/7 (PR with the enum change) - v12
4. https://github.com/LBHackney-IT/patches-and-areas-shared/pull/8 (PR with the docker-compose change) - v13

The only real change is the v12, which is the intended shared package change update for this PR.