### PR TITLE
Update dev and staging lambda authorizer

### DIFF
--- a/PatchesAndAreasApi/serverless.yml
+++ b/PatchesAndAreasApi/serverless.yml
@@ -30,7 +30,7 @@ functions:
           path: /{proxy+}
           method: ANY
           authorizer:
-            arn: ${ssm:/api-authenticator/${self:provider.stage}/arn}
+            arn: ${self:custom.authorizerArns.${opt:stage}}
             type: request
             resultTtlInSeconds: 0
             identitySource: method.request.header.Authorization
@@ -189,6 +189,10 @@ resources:
           Expression: rate(5 minutes)
           DurationInSeconds: 0
 custom:
+  authorizerArns:
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-development-apiauthverifytoken
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-production-apiauthverifytoken
   safeguards:
     - title: Require authorizer
       safeguard: require-authorizer

--- a/PatchesAndAreasApi/serverless.yml
+++ b/PatchesAndAreasApi/serverless.yml
@@ -190,7 +190,7 @@ resources:
           DurationInSeconds: 0
 custom:
   authorizerArns:
-    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-development-apiauthverifytoken
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-production-apiauthverifytoken
   safeguards:


### PR DESCRIPTION
Update staging lambda authorizer

- Hardcode authorizer ARNs in serverless, preventing any unintended changes via parameter store
- Update staging authorizer to the new version