### PR TITLE
Change JWT core from being an implicit dependency to explicit one, and bump to `v1.87.0`.

### DIFF
--- a/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
+++ b/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.55.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />

--- a/PatchesAndAreasApi/PatchesAndAreasApi.csproj
+++ b/PatchesAndAreasApi/PatchesAndAreasApi.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.8.1" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.9.1" />
     <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />


### PR DESCRIPTION
# What:
 - Make `Hackney.Core.JWT` be an **explicit** dependency instead of an **implicit** one.
 - Update the `Hackney.Core.JWT` package 2 versions up _(1.72 -> 1.84 -> 1.87)_.

# Why:
 - This C# solution is **directly** referencing the JWT core package across both its projects: using JWT namespaces, methods, and interfaces. Issue is that this package is **not referenced as a direct dependency** within the `.csproj` files. Instead, package is imported through `Hackney.Core.Authorization`. When the restore happens, Authorization package is build, which contains the binaries from JWT due to a weak link between the 2.
 - To get the latest version of the `ITokenFactory` implementation that adds support for the Cognito token schema.
 - The current v1.72 implementation crashes upon encountering Cognito Token due to empty `groups` key failing to map and leading `Token.Groups` to getting set as unhandled `null`.

# Notes:
 - Updating only the `JWT` core package without the `Authorizer` as after additional digging through source code I've found that `Authorizer` core package merely references the `JWT` core package's `ITokenFactory` interface definition, and does not do anything more with the package. The way the Google groups authentication setup works is that for any given API, it uses `JWT` core package to register `TokenFactory` instance DI, and then that gets used by the Authorizer middleware to populate its Auth filter dependencies. The rest of the `JWT` usage seems to be limited down to `Token` class to extract data like email or user name for Activity History purposes.
 - Not updating the Authorizer as it seems to have additional functionality introduced apart JWT version upgrade, that would need extra testing. As it stands right now, due to the above reason, it does not need to be bumped on the APIs.
 - The version `1.84` was a fake release, accidentally triggered by some house cleaning done by the cyber team.
 - What changes does latest JWT intoduce? See PR: https://github.com/LBHackney-IT/lbh-core/pull/68.