### PR TITLE
Release #69, #71, and #72 to staging.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,7 +145,8 @@ jobs:
   build-and-test:
     executor: docker-python
     steps:
-      - checkout
+      - checkout:
+          method: full
       - setup_remote_docker
       - sonarcloud/scan
       - run:

--- a/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
+++ b/PatchesAndAreasApi.Tests/PatchesAndAreasApi.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.55.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />

--- a/PatchesAndAreasApi/PatchesAndAreasApi.csproj
+++ b/PatchesAndAreasApi/PatchesAndAreasApi.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.8.1" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.9.1" />
     <PackageReference Include="Hackney.Core.Authorization" Version="1.78.0" />
+    <PackageReference Include="Hackney.Core.JWT" Version="1.87.0" />
     <PackageReference Include="Hackney.Core.DynamoDb" Version="1.51.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.49.0" />

--- a/PatchesAndAreasApi/serverless.yml
+++ b/PatchesAndAreasApi/serverless.yml
@@ -190,7 +190,7 @@ resources:
           DurationInSeconds: 0
 custom:
   authorizerArns:
-    development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
+    development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   safeguards:

--- a/terraform/production/dynamodb.tf
+++ b/terraform/production/dynamodb.tf
@@ -16,7 +16,7 @@ resource "aws_dynamodb_table" "PatchesAndAreasApi_dynamodb_table" {
   }
   
   attribute {
-    name = "patchName"
+    name = "name"
     type = "S"
   }
   
@@ -30,7 +30,7 @@ resource "aws_dynamodb_table" "PatchesAndAreasApi_dynamodb_table" {
 
   global_secondary_index {
     name               = "PatchByPatchName"
-    hash_key           = "patchName"
+    hash_key           = "name"
     write_capacity     = 10
     read_capacity      = 10
     projection_type    = "ALL"

--- a/terraform/staging/dynamodb.tf
+++ b/terraform/staging/dynamodb.tf
@@ -16,7 +16,7 @@ resource "aws_dynamodb_table" "PatchesAndAreasApi_dynamodb_table" {
   }
   
   attribute {
-    name = "patchName"
+    name = "name"
     type = "S"
   }
   
@@ -30,7 +30,7 @@ resource "aws_dynamodb_table" "PatchesAndAreasApi_dynamodb_table" {
 
   global_secondary_index {
     name               = "PatchByPatchName"
-    hash_key           = "patchName"
+    hash_key           = "name"
     write_capacity     = 10
     read_capacity      = 10
     projection_type    = "ALL"


### PR DESCRIPTION
# What:
 - Releases seemingly abandoned PR #69 .
 - Releases #71 _(has no effect past dev env)_.
 - Releases #72 _(the actual target of the release)_.

# Why:
 - Preparation for `staging` deployment of cognito flow. As such, we need to ensure all the APIs are running against the latest JWT Nuget package that supports both token schemas.

# Notes:
 - Based on the PR #69 description, I'm assuming that this is merely house-keeping that will not adversely affect the staging or prod environments. However, this should be verified by the Housing-Product team.