### PR TITLE
Revert to not filtering on patches isDisabled flag

### DIFF
--- a/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
+++ b/PatchesAndAreasApi.Tests/V1/Gateways/DynamoDbGatewayTests.cs
@@ -121,27 +121,6 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
         }
 
         [Fact]
-        public async Task GetPatchByIdReturnsDisabledPatchIfItExists()
-        {
-            //Arrange
-            var entity = _fixture.Build<PatchEntity>()
-                                 .With(x => x.IsDisabled, true)
-                                 .With(x => x.VersionNumber, (int?) null)
-                                 .Create();
-            var dbEntity = entity.ToDatabase();
-
-            await InsertDataToDynamoDB(dbEntity).ConfigureAwait(false);
-
-            var query = ConstructQuery(entity.Id);
-            //Act
-            var result = await _classUnderTest.GetPatchByIdAsync(query).ConfigureAwait(false);
-
-            //Assert
-            result.Should().BeEquivalentTo(dbEntity, config => config.Excluding(y => y.VersionNumber));
-            _logger.VerifyExact(LogLevel.Debug, $"Calling IDynamoDBContext.LoadAsync for id parameter {query.Id}", Times.Once());
-        }
-
-        [Fact]
         public async Task DeleteResponsibilityFromPatchWhenPatchDoesntExistThrowsException()
         {
             // Arrange
@@ -317,7 +296,6 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
         {
             // Arrange
             var patches = _fixture.Build<PatchesDb>()
-                                  .With(x => x.IsDisabled, false)
                                   .Without(x => x.VersionNumber)
                                   .CreateMany(5).ToList();
 
@@ -332,30 +310,6 @@ namespace PatchesAndAreasApi.Tests.V1.Gateways
                 results.Should().ContainEquivalentOf(patch.ToDomain());
             }
 
-            _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
-        }
-
-        [Fact]
-        public async Task GetAllPatchesAsyncDoesNotReturnDisabledPatches()
-        {
-            // Arrange
-            var enabledPatch = _fixture.Build<PatchesDb>()
-                                       .With(x => x.IsDisabled, false)
-                                       .Without(x => x.VersionNumber)
-                                       .Create();
-            var disabledPatch = _fixture.Build<PatchesDb>()
-                                        .With(x => x.IsDisabled, true)
-                                        .Without(x => x.VersionNumber)
-                                        .Create();
-
-            InsertListDataToDynamoDB(new List<PatchesDb> { enabledPatch, disabledPatch });
-
-            // Act
-            var results = await _classUnderTest.GetAllPatchesAsync().ConfigureAwait(false);
-
-            // Assert
-            results.Should().ContainEquivalentOf(enabledPatch.ToDomain());
-            results.Should().NotContain(x => x.Id == disabledPatch.Id);
             _logger.VerifyExact(LogLevel.Debug, "Calling IDynamoDBContext.ScanAsync for all PatchEntity records", Times.Once());
         }
 

--- a/PatchesAndAreasApi/PatchesAndAreasApi.csproj
+++ b/PatchesAndAreasApi/PatchesAndAreasApi.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.PatchesAndAreas" Version="0.17.0" />
+    <PackageReference Include="Hackney.Shared.PatchesAndAreas" Version="0.16.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/PatchesAndAreasApi/PatchesAndAreasApi.csproj
+++ b/PatchesAndAreasApi/PatchesAndAreasApi.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Hackney.Core.Sns" Version="1.52.0" />
     <PackageReference Include="Hackney.Core.Validation" Version="1.56.0" />
     <PackageReference Include="Hackney.Core.Validation.AspNet" Version="1.53.0" />
-    <PackageReference Include="Hackney.Shared.PatchesAndAreas" Version="0.16.0" />
+    <PackageReference Include="Hackney.Shared.PatchesAndAreas" Version="0.18.0" />
     <PackageReference Include="Microsoft.AspNetCore.Cors" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="6.0.9" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.0.0" />

--- a/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
+++ b/PatchesAndAreasApi/V1/Gateways/PatchesGateway.cs
@@ -38,8 +38,7 @@ namespace PatchesAndAreasApi.V1.Gateways
             var scanConfig = new ScanOperationConfig();
 
             var tableScan = await _dynamoDbContext.GetTargetTable<PatchesDb>().Scan(scanConfig).GetRemainingAsync().ConfigureAwait(false);
-            var result = _dynamoDbContext.FromDocuments<PatchesDb>(tableScan)
-                                         .Where(x => !x.IsDisabled);
+            var result = _dynamoDbContext.FromDocuments<PatchesDb>(tableScan);
 
             return result.Select(x => x.ToDomain()).ToList();
         }


### PR DESCRIPTION
The old patches are going to stay for now, so the flag has been removed and the API will not use it to filter for patches to be displayed.